### PR TITLE
Added Gnome '43'

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,5 +14,5 @@
   ],
   "url": "https://github.com/jackkenney/gnome-true-color-invert",
   "uuid": "true-color-invert@jackkenney",
-  "version": 12_indev
+  "version": 12
 }

--- a/metadata.json
+++ b/metadata.json
@@ -9,9 +9,10 @@
     "3.38",
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "url": "https://github.com/jackkenney/gnome-true-color-invert",
   "uuid": "true-color-invert@jackkenney",
-  "version": 10
+  "version": 12_indev
 }


### PR DESCRIPTION
As the extension continued to function fine on Gnome 43, It's now been added to 'metadata.json'